### PR TITLE
fix(project search): add revision field that is present in 7.9

### DIFF
--- a/sonar/components_service.go
+++ b/sonar/components_service.go
@@ -37,6 +37,7 @@ type Component struct {
 	UUID             string          `json:"uuid,omitempty"`
 	Version          string          `json:"version,omitempty"`
 	Visibility       string          `json:"visibility,omitempty"`
+	Revision         string          `json:"revision,omitempty"`
 }
 
 type ComponentsTreeObject struct {


### PR DESCRIPTION
The sonarqube api docs note the response can look like the following:

```json
{
  "paging": {
    "pageIndex": 1,
    "pageSize": 100,
    "total": 2
  },
  "components": [
    {
      "organization": "my-org-1",
      "id": "project-uuid-1",
      "key": "project-key-1",
      "name": "Project Name 1",
      "qualifier": "TRK",
      "visibility": "public",
      "lastAnalysisDate": "2017-03-01T11:39:03+0300",
      "revision": "cfb82f55c6ef32e61828c4cb3db2da12795fd767"
    },
    {
      "organization": "my-org-1",
      "id": "project-uuid-2",
      "key": "project-key-2",
      "name": "Project Name 1",
      "qualifier": "TRK",
      "visibility": "private",
      "lastAnalysisDate": "2017-03-02T15:21:47+0300",
      "revision": "7be96a94ac0c95a61ee6ee0ef9c6f808d386a355"
    }
  ]
}
```

Currently, the `revision` field isn't present in the struct so the library returns the error of `json: unknown field "revision"`.