### PR TITLE
Add branch to Task

### DIFF
--- a/sonar/ce_service.go
+++ b/sonar/ce_service.go
@@ -22,6 +22,8 @@ type CeTaskObject struct {
 
 type Task struct {
 	AnalysisID         string   `json:"analysisId,omitempty"`
+	Branch             string   `json:"branch,omitempty"`
+	BranchType         string   `json:"branchType,omitempty"`
 	ComponentID        string   `json:"componentId,omitempty"`
 	ComponentKey       string   `json:"componentKey,omitempty"`
 	ComponentName      string   `json:"componentName,omitempty"`

--- a/sonar/client.go
+++ b/sonar/client.go
@@ -81,3 +81,10 @@ func NewClient(endpoint, username, password string) (*Client, error) {
 	c.Webhooks = &WebhooksService{client: c}
 	return c, nil
 }
+
+func NewClientByToken(endpoint, token string) (*Client, error) {
+	c, err := NewClient(endpoint, "", "")
+	c.token = token
+	c.authType = privateToken
+	return c, err
+}


### PR DESCRIPTION
I want to use sonargo with the current Sonar version for receiving Task objects.
There were some additions to the task object (branch). I don't really need those, but since unknown fields in JSON are disallowed, I had to add them to the struct in order to get it work again.

Should be compatible with earlier versions.

This addition is by no means complete. I think `branch` is also an option for filtering which I didn't add because I'm not using it.