### PR TITLE
Added lastConnectionDate

### DIFF
--- a/sonar/users_service.go
+++ b/sonar/users_service.go
@@ -12,18 +12,19 @@ type UsersCreateObject struct {
 }
 
 type User struct {
-	Active           bool     `json:"active,omitempty"`
-	Email            string   `json:"email,omitempty"`
-	Local            bool     `json:"local,omitempty"`
-	Login            string   `json:"login,omitempty"`
-	Name             string   `json:"name,omitempty"`
-	ScmAccounts      []string `json:"scmAccounts,omitempty"`
-	Selected         bool     `json:"selected,omitempty"`
-	TokensCount      int      `json:"tokensCount,omitempty"`
-	ExternalIdentity string   `json:"externalIdentity,omitempty"`
-	ExternalProvider string   `json:"externalProvider,omitempty"`
-	Groups           []string `json:"groups,omitempty"`
-	Avatar           string   `json:"avatar,omitempty"`
+	Active             bool     `json:"active,omitempty"`
+	Email              string   `json:"email,omitempty"`
+	Local              bool     `json:"local,omitempty"`
+	Login              string   `json:"login,omitempty"`
+	Name               string   `json:"name,omitempty"`
+	ScmAccounts        []string `json:"scmAccounts,omitempty"`
+	Selected           bool     `json:"selected,omitempty"`
+	TokensCount        int      `json:"tokensCount,omitempty"`
+	ExternalIdentity   string   `json:"externalIdentity,omitempty"`
+	ExternalProvider   string   `json:"externalProvider,omitempty"`
+	LastConnectionDate string   `json:"lastConnectionDate,omitempty"`
+	Groups             []string `json:"groups,omitempty"`
+	Avatar             string   `json:"avatar,omitempty"`
 }
 
 type UsersChangePasswordOption struct {


### PR DESCRIPTION
On the users service there was an error where the data from a user object couldn't be unmarshalled because of this (apparently) new attribute returned from the API. Here's an example response from an API query for user search:

```
{"paging":{"pageIndex":1,"pageSize":5,"total":1},"users":[{"login":"my-name","name":"my-name","active":true,"email":"redacted@redacted","groups":["sonar-users"],"tokensCount":0,"local":false,"externalIdentity":"redacted@redacted","externalProvider":"saml","avatar":"1ac9be3cd90229693c5d52490805a9d4","lastConnectionDate":"2020-12-14T22:14:30-0500"}]}
```

I'm using version 8.4.2.36762, and have confirmed that the user API seems to be functional with this change.